### PR TITLE
Check for zero value when casting to error

### DIFF
--- a/json.go
+++ b/json.go
@@ -120,9 +120,12 @@ func toJSON(field Field) (EncodedField, bool) {
 		subfields := extractStructAsFields(v)
 		return toJSONObject(subfields), true
 	default:
-		if err, ok := v.Interface().(error); ok {
-			return EncodedField(strconv.Quote(err.Error())), true
+		if !v.IsZero() {
+			if err, ok := v.Interface().(error); ok {
+				return EncodedField(strconv.Quote(err.Error())), true
+			}
 		}
+
 	}
 	return "", false
 }

--- a/json.go
+++ b/json.go
@@ -99,6 +99,10 @@ func toJSONArray(values []Field) EncodedField {
 func toJSON(field Field) (EncodedField, bool) {
 	v := reflect.ValueOf(field)
 
+	if field == nil {
+		return "", false
+	}
+
 	switch v.Kind() {
 	case reflect.Bool:
 		return EncodedField(fmt.Sprintf("%v", v.Bool())), true
@@ -120,12 +124,9 @@ func toJSON(field Field) (EncodedField, bool) {
 		subfields := extractStructAsFields(v)
 		return toJSONObject(subfields), true
 	default:
-		if !v.IsZero() {
-			if err, ok := v.Interface().(error); ok {
-				return EncodedField(strconv.Quote(err.Error())), true
-			}
+		if err, ok := v.Interface().(error); ok {
+			return EncodedField(strconv.Quote(err.Error())), true
 		}
-
 	}
 	return "", false
 }

--- a/log_test.go
+++ b/log_test.go
@@ -210,6 +210,15 @@ func TestAlteringMapsDoesNotChangeLog(t *testing.T) {
 	require.EqualValues(t, map[string]interface{}{"woo": "yay"}, logLine["values"])
 }
 
+func TestHandleEmptyInterface(t *testing.T) {
+	var user interface{}
+	buffer := &bytes.Buffer{}
+	logger := antilog.WithWriter(buffer)
+	logger.With("user", user)
+
+	require.Equal(t, "", buffer.String())
+}
+
 func BenchmarkLogWithNoFields(b *testing.B) {
 	buffer := &bytes.Buffer{}
 	logger := antilog.WithWriter(buffer)


### PR DESCRIPTION
The logger was panicking:

`reflect: call of reflect.Value.Interface on zero Value: ValueError`

```
{
"path": "github.com/shamaazi/antilog@v1.0.2/json.go",
"line": 123,
"label": "toJSON"
}
```